### PR TITLE
Ignore ETH-related combinations due to bug in swapping for it

### DIFF
--- a/test/page_near-web3/specs/swapping.spec.ts
+++ b/test/page_near-web3/specs/swapping.spec.ts
@@ -32,11 +32,12 @@ test.describe(
       await homePage.confirmSwapButtonNotAvailable()
     })
 
+    // FIXME: Undo the ETH combinations once https://app.clickup.com/t/86eta3nby is fixed
     const tokensFromTo = [
       { tokenFrom: "NEAR", tokenTo: "USDt", swapAmount: 0.000001 },
       { tokenFrom: "NEAR", tokenTo: "USDT.e", swapAmount: 0.000001 },
-      { tokenFrom: "NEAR", tokenTo: "ETH", swapAmount: 0.000001 },
-      { tokenFrom: "ETH", tokenTo: "NEAR", swapAmount: 0.00000001 },
+      // { tokenFrom: "NEAR", tokenTo: "ETH", swapAmount: 0.000001 },
+      // { tokenFrom: "ETH", tokenTo: "NEAR", swapAmount: 0.00000001 },
       { tokenFrom: "USDT.e", tokenTo: "NEAR", swapAmount: 0.000001 },
       { tokenFrom: "USDt", tokenTo: "NEAR", swapAmount: 0.000001 },
     ]


### PR DESCRIPTION
Due to https://app.clickup.com/t/86eta3nby skipping ETH swapping combinations