### PR TITLE
Try retrying the cache generation due to Synpress browser extension timeouts

### DIFF
--- a/.github/workflows/e2e-worker.yml
+++ b/.github/workflows/e2e-worker.yml
@@ -78,8 +78,12 @@ jobs:
         run: yarn playwright install
 
       - name: Create Synpress cache
-        run: |
-          xvfb-run yarn synpress
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 5
+          shell: bash
+          command: xvfb-run yarn synpress
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This PR tries to stabilise the Synpress cache generation issue:
```
Error: [WaitForExtensionOnLoadPage] Extension did not load in time!
    at waitForExtensionOnLoadPage (file:///home/runner/work/aurora-e2e-tests/aurora-e2e-tests/node_modules/@synthetixio/synpress-cache/dist/index.js:232:13)
    at async createCacheForWalletSetupFunction (file:///home/runner/work/aurora-e2e-tests/aurora-e2e-tests/node_modules/@synthetixio/synpress-cache/dist/index.js:249:25)
    at async Promise.all (index 1)
    at async createCache (file:///home/runner/work/aurora-e2e-tests/aurora-e2e-tests/node_modules/@synthetixio/synpress-cache/dist/index.js:315:3)
    at async cliEntrypoint (file:///home/runner/work/aurora-e2e-tests/aurora-e2e-tests/node_modules/@synthetixio/synpress-cache/dist/index.js:1[21](https://github.com/aurora-is-near/aurora-e2e-tests/actions/runs/14901792652/job/41855165022#step:8:22)3:3
```
  fix is to retry the step via custom action https://github.com/marketplace/actions/retry-step to retry 5 times until sucess