### PR TITLE
Fix the Metamask import duplicate account issues

### DIFF
--- a/test/wallet-setup/near-web3-prod.setup.ts
+++ b/test/wallet-setup/near-web3-prod.setup.ts
@@ -1,7 +1,6 @@
 import { defineWalletSetup } from "@synthetixio/synpress"
 import "dotenv/config"
 import { getExtensionId, MetaMask } from "@synthetixio/synpress/playwright"
-// import { setTimeout } from "timers/promises"
 import { NEAR_WALLET_MAINNET } from "../helpers/constants/networks"
 import {
   getPassword,


### PR DESCRIPTION
Now import with SRP adds the second account as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Simplified wallet setup by removing the private-key import flow and associated delays.
  - Standardized on seed-phrase import, then switches to the second account and adds the NEAR mainnet without waiting.
  - Speeds up and stabilizes test execution with fewer timing dependencies.
  - No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->